### PR TITLE
Fix carthage build fail

### DIFF
--- a/RxMultipeer.xcodeproj/xcshareddata/xcschemes/RxMultipeer.xcscheme
+++ b/RxMultipeer.xcodeproj/xcshareddata/xcschemes/RxMultipeer.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
#### Issue

When use this library with Carthage.
Building fail with below message because of config.

This PR fix it.

```
➜  RxMultipeerTrial carthage update --platform iOS
*** Fetching RxMultipeer
*** Fetching RxSwift
*** Checking out RxSwift at "2.6.0"
*** Checking out RxMultipeer at "5d3ffcbfbadb31f8a824ea7d150eca7eb5eef51f"
*** xcodebuild output can be found in /var/folders/9l/3_q0bnkx40jb9ywzrsprr0z56cd_w1/T/carthage-xcodebuild.hNpZgx.log
*** Building scheme "RxBlocking-iOS" in Rx.xcworkspace
*** Building scheme "RxTests-iOS" in Rx.xcworkspace
*** Building scheme "RxSwift-iOS" in Rx.xcworkspace
*** Building scheme "RxCocoa-iOS" in Rx.xcworkspace
*** Building scheme "RxMultipeer" in RxMultipeer.xcodeproj
** BUILD FAILED **


The following build commands failed:
    CompileSwift normal arm64 /Users/majima/develop/iOS/trial/RxMultipeerTrial/Carthage/Checkouts/RxMultipeer/RxMultipeerTests/IntegrationSpec.swift
    CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler
(2 failures)
/Users/majima/develop/iOS/trial/RxMultipeerTrial/Carthage/Checkouts/RxMultipeer/RxMultipeerTests/IntegrationSpec.swift:2:8: error: no such module 'Quick'
A shell task (/usr/bin/xcrun xcodebuild -project /Users/majima/develop/iOS/trial/RxMultipeerTrial/Carthage/Checkouts/RxMultipeer/RxMultipeer.xcodeproj -scheme RxMultipeer -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
** BUILD FAILED **


The following build commands failed:
    CompileSwift normal arm64 /Users/majima/develop/iOS/trial/RxMultipeerTrial/Carthage/Checkouts/RxMultipeer/RxMultipeerTests/IntegrationSpec.swift
    CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler
(2 failures)

```
