### PR TITLE
Stop Client.connected() emitting unnecessarily

### DIFF
--- a/RxMultipeer/Adapters/MultipeerConnectivitySession.swift
+++ b/RxMultipeer/Adapters/MultipeerConnectivitySession.swift
@@ -397,7 +397,11 @@ extension MultipeerConnectivitySession : MCSessionDelegateWrapperDelegate {
   public func session(_ session: MCSession,
                       peer peerID: MCPeerID,
                       didChange state: MCSessionState) {
-    _connections.value = session.connectedPeers
+    // If the peer is connecting, then we know that connected peers has not
+    // changed, so we can avoid re-emitting the observable by not setting the value
+    if state != .connecting {
+      _connections.value = session.connectedPeers
+    }
   }
 
   public func session(_ session: MCSession,


### PR DESCRIPTION
I found that I was seeing values emitted on the Client.connected()
observable when a peer was connecting but not yet connected.

A connecting peer does not change the `connectedPeers` property of
the `MCSession`, but it does cause a call to the
`session(_:peer:didChange:)` method on the delegate. This means that the
delegate proxy will set the value of `_connected` even when there is no
change to the `connectedPeers` value it passes.

This change simply checks if the `state` of the peer is `.connecting`.
If it is not (ie. it is `connected` or `disconnected`) then we update
the value of `_connected` (and thus `connected()`).